### PR TITLE
add route and controler to user state on a group

### DIFF
--- a/requests/userStateGroup.rest
+++ b/requests/userStateGroup.rest
@@ -1,0 +1,7 @@
+GET http://localhost:3002/Users/userStateGroup
+content-type: application/json
+
+{
+  "username":"salvarezri",
+  "groupName":"group1"
+}

--- a/src/controllers/users.controllers.ts
+++ b/src/controllers/users.controllers.ts
@@ -136,6 +136,7 @@ class UserController {
 
   // Get info of an specific user
   public async userInfo (req: Request, res: Response, _next: NextFunction): Promise<void> {
+    console.log('entering user info')
     const username = req.params.username
     await UserModel.find({ username }, { _id: 0, __v: 0 })
       .then((user) => {
@@ -150,6 +151,32 @@ class UserController {
         res.status(500).send({ err })
         console.log('Error finding user', err.message)
       })
+  }
+
+  public async userStateGroup (req: Request, res: Response, _next: NextFunction): Promise<void> {
+    const { username, groupName } = req.body
+    if (username === undefined || groupName === undefined) {
+      res.status(400).send({ err: 'Bad request' })
+      return
+    }
+    const userDocument: UserDocument | null = await UserModel.findOne({ username })
+    if (userDocument === null) {
+      res.status(404).send({ err: 'User not found' })
+      return
+    }
+    let state = 'notBelongs'
+    userDocument.requests.forEach(element => {
+      if (element.groupName === groupName && element.state === 'pending') {
+        state = 'pending'
+      }
+    })
+    userDocument.groups.forEach(element => {
+      if (element.groupName === groupName) {
+        state = 'belongs'
+      }
+    })
+    console.log(username, 'state in group', groupName, ' is: "', state, '"')
+    res.status(200).send({ state })
   }
 
   // Test Route

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -9,6 +9,7 @@ router.get('/', usersControllers.getUsers)// Ruta de Obtención de Usuarios
 router.get('/seeUser/:username', usersControllers.userInfo) // Ruta de Obtención de información un usuario
 router.post('/createUser', auth0Controllers.getUserData, usersControllers.createUser) // Ruta de Creacion de Usuario
 router.delete('/quitGroup', auth0Controllers.getUserData, usersControllers.quitGroup) // Ruta de Salir de un grupo
+router.get('/userStateGroup', usersControllers.userStateGroup) // Ruta de Obtención de estado de un usuario en un grupo
 
 // Test route
 router.get('/doomie', usersControllers.doomie)


### PR DESCRIPTION
**Background**
A route had to be created to get the status of a user on a group. If the user is part of the group, answer "belongs"; if the user has a request made to the group, answer "pending"; if the user does not meet any of the above, answer "notBelongs".
**Changes done**
Se creo una ruta (/Users/userStateGroup) a la que le entra el nombre de usuario (username) y el nombre del grupo. Esta ruta devuelve un JSON con el estado de acuerdo con lo planteado.
**Pending to be done**
If required, it remains to pass the JSON input values to the url itself. It is also pending to apply the authentication middleware because I didn't find it necessary to validate the user to obtain this information.
**Example**
in DB:
![image](https://user-images.githubusercontent.com/75555138/232927777-d63dbfc5-b674-4b8e-9f00-1f66851a5d7a.png)
request/response:
![image](https://user-images.githubusercontent.com/75555138/232927626-7bcb9cba-ab84-49f6-a72a-3c6a5da77d48.png)
