### PR TITLE
Add route to get related groups

### DIFF
--- a/requests/relatedGroups.rest
+++ b/requests/relatedGroups.rest
@@ -1,0 +1,2 @@
+GET  http://localhost:3002/groups/seeGroup/i1/related
+content-type: application/json

--- a/src/controllers/groups.controllers.ts
+++ b/src/controllers/groups.controllers.ts
@@ -106,6 +106,11 @@ class GroupsController {
     res.send('members')
   }
 
+  public async related (req: Request, res: Response, _next: NextFunction): Promise<void> {
+    const groupname = req.params.groupname
+    res.send('related to ' + groupname)
+  }
+
   // Test route
   public async doomie (req: Request, res: Response, _next: NextFunction): Promise<void> {
     const n = req.query.n

--- a/src/routes/groups.routes.ts
+++ b/src/routes/groups.routes.ts
@@ -10,6 +10,7 @@ router.get('/', groupsControllers.getGroups) // Ruta de Obtención de Grupos
 router.get('/seeGroup/:groupname', groupsControllers.groupInfo) // Ruta de Obtención de información un grupo
 router.post('/createGroup', aut0Controllers.getUserData, usersMiddlewares.checkUserExist, groupsControllers.createGroup) // Ruta de Creacion de Grupo
 router.get('/seeGroup/:groupname/members', groupsControllers.members) // Ruta para obtener los miembros de un grupo
+router.get('/seeGroup/:groupname/related', groupsControllers.related) // Ruta para obtener las solicitudes de un grupo
 
 // Test route
 router.get('/doomie', groupsControllers.doomie)


### PR DESCRIPTION
**Background**
There should be a route to get groups related witch one specific group
**Changes done**
Create route into groups/seeGroup/-groupname-/related
**Pending to be done**
make functions (UNITED-71)
**Example**
![image](https://user-images.githubusercontent.com/75555138/233491738-47aeedff-a7c4-408e-8dc7-56b0c14ea335.png)
