### PR TITLE
UNITED-71- add get related groups functionality

### DIFF
--- a/requests/createGroup.rest
+++ b/requests/createGroup.rest
@@ -4,7 +4,7 @@ content-type: application/json
 {
   "group":{
       "info":{
-          "name":"i1",
+          "name":"salv18",
           "description": "Ut elit aliqua ut irure cillum irure culpa. Aute elit irure velit sit cupidatat veniam amet qui incididunt dolore consequat cillum Lorem. Cupidatat fugiat occaecat esse fugiat velit consectetur minim veniam aute deserunt cupidatat adipisicing cupidatat.",
           "contact":{
               "mail":"UNitedGroup1@group.com",
@@ -20,9 +20,9 @@ content-type: application/json
           },
           "numberOfMembers": 1,
           "topics":[
-              "ingeniería",
-              "arduino",
-              "señales"
+              "futbol",
+              "cocina",
+              "Carreras"
           ],
           "classification":"Académico",
           "isRecognized": true,
@@ -36,5 +36,8 @@ content-type: application/json
           "creationDate": "2018-04-03",
           "referenceImg": "https://www.conexionverde.com/storage/2012/11/grupos-estudiantiles-gpg.jpg"
       }
+  },
+  "user":{
+    "nickname": "salvarezri"
   }
 }

--- a/requests/relatedGroups.rest
+++ b/requests/relatedGroups.rest
@@ -1,2 +1,2 @@
-GET  http://localhost:3002/groups/seeGroup/i1/related
+GET  http://localhost:3002/groups/seeGroup/salv13/related?n=5&a=0
 content-type: application/json

--- a/src/config/defaultOptions.ts
+++ b/src/config/defaultOptions.ts
@@ -3,5 +3,9 @@ export const groupsRoutesOptions = {
   index: {
     n: 5,
     offset: 0
+  },
+  related: {
+    n: 5,
+    offset: 0
   }
 }

--- a/src/models/Group.model.ts
+++ b/src/models/Group.model.ts
@@ -27,7 +27,7 @@ const GroupInfoShema = new Schema({
   description: { type: String, required: true },
   contact: ContactShema,
   numberOfMembers: { type: Number, required: true, default: 1 },
-  topics: [{ type: [String], required: true }],
+  topics: [{ type: String, required: true }],
   clasification: { type: String, required: true, enum: Object.values(Classification), default: Classification.other },
   isRecognized: { type: Boolean, required: true },
   recognizedInfo: { type: RecognizedInfoShema, required: false },

--- a/src/services/related.service.ts
+++ b/src/services/related.service.ts
@@ -1,0 +1,83 @@
+import GroupModel from '../models/Group.model'
+import { GroupDocument, GroupInfo } from '../models/group.documents'
+
+interface RelatedGroup {
+  // object with the group info, the topics that are related to it and the number of coincidences
+  group: GroupInfo
+  topics: [String]
+  count: number
+}
+
+class RelatedService {
+  public async getBestRelatedGroups (topics: String[], groupName: string = '', n: number = 5, offset: number = 0): Promise<RelatedGroup[] | undefined> {
+    // get all related groups
+    const allRelated = await this.obtainAllRelatedGroups(topics, groupName)
+      .catch((err): null => {
+        console.log('Error obtaining related groups', err.message)
+        return null
+      })
+    // sort them by count (first the most coincidences)
+    const bestRelated = allRelated?.sort((a, b) => {
+      return b.count - a.count
+    })
+    // return the best n groups with an offset
+    if (bestRelated === undefined) return undefined
+    return bestRelated.slice(offset, offset + n)
+  }
+
+  public async obtainAllRelatedGroups (topics: String[], groupName: String = ''): Promise<RelatedGroup[]> {
+    // create a dictionary with the groups and the topics that are related to them
+    const dict = new Map<String, RelatedGroup>()
+    // iterate over all topics
+    for (const topic of topics) {
+      // select all groups that have the topic
+      await this.hasTopic(topic, groupName)
+        .then((groups) => {
+          // iterate over all groups that have the topic
+          groups?.forEach((group) => {
+            // if the group is already in the dictionary, add the topic to the list of topics and increase the count
+            if (dict.has(group.name)) {
+              const obtainGroup = dict.get(group.name)
+              if (obtainGroup !== undefined) {
+                obtainGroup.topics.push(topic)
+                obtainGroup.count += 1
+              }
+              // if the group is not in the dictionary, add it to the dictionary
+            } else {
+              dict.set(group.name, { group, topics: [topic], count: 1 })
+            }
+          })
+        })
+        .catch((err): void => {
+          console.log('Error finding related groups', err.message)
+        })
+    }
+    // return the dictionary as a list
+    const listDict = Array.from(dict.values())
+    console.log('related to', groupName, listDict.map((group: RelatedGroup) => {
+      return group.group.name + ' - ' + group.count.toString() + ' - ' + group.topics.join(', ')
+    }
+    ))
+    return listDict
+  }
+
+  public async hasTopic (topic: String, groupName: String = ''): Promise<GroupInfo[] | null> {
+    // select all groups that have the topic
+    const groups = await GroupModel.find({
+      'info.topics': topic,
+      // do not obtain the group itself
+      'info.name': { $ne: groupName }
+    }, 'info', { _id: 0, __v: 0 })
+      .then((groups: GroupDocument[]) => {
+        // return the info of the groups
+        return groups.map((group) => {
+          return group.info
+        })
+      })
+      .catch((err): void => {
+        console.log('Error finding related groups', err.message)
+      })
+    return groups === undefined ? null : groups
+  }
+}
+export default new RelatedService()


### PR DESCRIPTION
**Background**
There should be a route to get the groups wich have some relation with an especific group

**Changes done**

- Update models to save correctly the topics
- Make some functions to get related groups
- The route obtains the params from the url

**Pending to be done**
nothing

**Example**
![Captura de pantalla 2023-04-20 223952](https://user-images.githubusercontent.com/75555138/233539711-db1456ea-031d-4029-a442-fc036a5f625a.png)
