### PR TITLE
United 86 webmaster check role

### DIFF
--- a/src/middlewares/users.middlewares.ts
+++ b/src/middlewares/users.middlewares.ts
@@ -32,14 +32,14 @@ class UserMiddlewares {
       res.status(400).json({ message: 'Missing user information' })
       console.log('Missing user information')
     }
-    console.log(user)
     // Check if user is webmaster
     const isWebmaster: boolean | null = await userService.isWebmaster(user.username)
-    console.log(isWebmaster)
+    // If error
     if (isWebmaster === null) {
       res.status(500).json({ message: 'Error checking user role' })
       console.log('Error checking user role')
     } else if (isWebmaster) {
+      console.log('User has webmaster role')
       next()
     } else {
       res.status(401).json({ message: 'User doesn\'t have webmaster role' })

--- a/src/middlewares/users.middlewares.ts
+++ b/src/middlewares/users.middlewares.ts
@@ -22,6 +22,30 @@ class UserMiddlewares {
       console.log('User doesn\'t exists, you should create an account')
     }
   }
+
+  public async checkWebmasterRole (req: Request, res: Response, next: NextFunction): Promise<void> {
+    // Get user
+    const { user } = req.body
+
+    // Check if info is given
+    if (user === undefined || user.username === undefined) {
+      res.status(400).json({ message: 'Missing user information' })
+      console.log('Missing user information')
+    }
+    console.log(user)
+    // Check if user is webmaster
+    const isWebmaster: boolean | null = await userService.isWebmaster(user.username)
+    console.log(isWebmaster)
+    if (isWebmaster === null) {
+      res.status(500).json({ message: 'Error checking user role' })
+      console.log('Error checking user role')
+    } else if (isWebmaster) {
+      next()
+    } else {
+      res.status(401).json({ message: 'User doesn\'t have webmaster role' })
+      console.log('User doesn\'t have webmaster role')
+    }
+  }
 }
 
 export default new UserMiddlewares()

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -20,10 +20,13 @@ class USerService {
   public async isWebmaster (username: string): Promise<boolean | null> {
     const userDoc: UserDocument | null = await UserModel.findOne({ username })
       .catch((error: Error) => {
+        // return null to handle error in the middleware
         console.log(error.message)
         return null
       })
+    // if user is not defined
     if (userDoc == null) return null
+    // if user is not webmaster (isMaster is optional)
     if (userDoc.isMaster === undefined || userDoc.isMaster === null || !userDoc.isMaster) return false
     return true
   }

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,4 +1,5 @@
 import UserModel from '../models/User.model'
+import { UserDocument } from '../models/user.documents'
 
 class USerService {
   public async userExists (username: string): Promise<boolean> {
@@ -14,6 +15,17 @@ class USerService {
     } else {
       return false
     }
+  }
+
+  public async isWebmaster (username: string): Promise<boolean | null> {
+    const userDoc: UserDocument | null = await UserModel.findOne({ username })
+      .catch((error: Error) => {
+        console.log(error.message)
+        return null
+      })
+    if (userDoc == null) return null
+    if (userDoc.isMaster === undefined || userDoc.isMaster === null || !userDoc.isMaster) return false
+    return true
   }
 }
 


### PR DESCRIPTION
**Background**

> I was asked to work on the functionality create a middleware to check if a user is webmaster, so onoly if a user is webMaster can access to some routes.

**Changes done**

- A new function in users.middlewares.

- A new function in user.services to check if user is webmaster

**Notes**

> We need to put the middleware in the specific toutes

**Demo**

- add test middleware in a basic route to check functionality 

> ![middleware added](https://user-images.githubusercontent.com/75555138/236707922-f96569b5-4f33-41e9-8bff-5097ea34568d.png)

- Then test in a random user in test db who has isMaster in false. After take screenshot, I delete isMaster fild and same result:

> user not allowed (has false in isMaster field or doesn´t have isMaster field)

> ![user not allowed](https://user-images.githubusercontent.com/75555138/236707962-072b10dd-74e5-4983-a399-3a88868f536d.png)

- Then i moddify isMaster field to true and check again:

> user allowed (isMaster field is true)

> ![user allowed](https://user-images.githubusercontent.com/75555138/236707989-09879dba-26e7-4ee5-9008-b00f07258a47.png)

